### PR TITLE
Update BottomNavigation.java

### DIFF
--- a/bottomnavigation/src/main/java/com/ss/bottomnavigation/BottomNavigation.java
+++ b/bottomnavigation/src/main/java/com/ss/bottomnavigation/BottomNavigation.java
@@ -254,6 +254,7 @@ public class BottomNavigation extends LinearLayout implements OnTabItemClickList
 
     public void setDefaultItem(int position) {
         this.defaultItem = position;
+        this.selectedItemPosition=position;
     }
 
     public int getDefaultItem() {


### PR DESCRIPTION
وقتی مقدار پیشفرض عددی غیر از صفر انتخاب میشه، بعد از اجرا اگر روی اولین تب که موقعت صفر داره زده بشه هیچ اتفاقی نمیافته (کار نمیکنه) چون مقدار متغیر
selectedItemPosition = 0
است! با توجه به شرطی که در تابع
onSelectedItemChanged
تعریف شده !
بنابراین لازمه که 
public void setDefaultItem(int position) {
        this.defaultItem = position;
        this.selectedItemPosition=position;  //this line is added!
    }